### PR TITLE
Add grid layout to the dashboard

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -95,6 +95,12 @@ html body .drawer.drawer-right .drawertoggle {
   border-radius: 0;
 }
 
+/* fix my courses page due to grid layout */
+.block_myoverview {
+  grid-column-start: 1;
+  grid-column-end: 4;
+}
+
 html .drawerheader {
   height: auto;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,20 @@ body.limitedwidth #page.drawers .main-inner {
 }
 
 /* reorder dashboard cards */
+#block-region-content {
+  display: grid !important;
+  gap: 12px;
+  grid-template: "courses   courses   timeline" 1fr
+                 "timeedit  timeedit  timeline" auto
+                 "sc        sc        events" auto
+                 "recent    recent    tools" / 6fr 6fr 4fr;
+}
+
+#block-region-content>span {
+  display: none;
+}
+
+/* reorder dashboard cards */
 aside#block-region-content {
   display: flex;
   flex-flow: column;
@@ -19,36 +33,36 @@ aside#block-region-content {
 
 /* Timeline card */
 aside#block-region-content section.block_timeline {
-  order: 2;
+  grid-area: timeline;
 }
 
 /* Recently accessed items card */
 aside#block-region-content section.block_recentlyaccesseditems {
-  order: 3;
+  grid-area: recent;
 }
 
 /* Starred courses card */
 aside#block-region-content section.block_starredcourses {
-  order: 1;
+  grid-area: courses;
 }
 
 /* Upcoming events card */
 aside#block-region-content section.block_calendar_upcoming {
-  order: 4;
+  grid-area: events;
 }
 /* TimeEdit */
 aside#block-region-content section.block_timeedit {
-  order: 5;
+  grid-area: timeedit;
 }
 
 /* Student councile events */
 aside#block-region-content section.block_sc {
-  order: 6;
+  grid-area: sc;
 }
 
 /* Study tools card */
 aside#block-region-content section.block_cohortspecifichtml {
-  order: 7;
+  grid-area: tools;
 }
 
 


### PR DESCRIPTION
Currently how it looks in light mode on dashboard:
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/7b417331-a3a1-4928-a824-677f6382465d">
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/ec80fcab-199a-46c3-9ab7-176d116ed4b6">
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/77ddf76c-1149-4ee4-bc39-b4d9db33c215">

In my courses:
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/7f50edaa-2c48-41a7-a391-4f8097765099">

Dashboard in darkmode:
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/8094486e-6343-4a59-9275-9765e322c846">
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/9ef1fa2f-d9d4-4d3a-80e6-628661846fa7">
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/cea6dbde-d9db-4396-9514-fda70af0e244">

My courses:
<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/be117ea0-e36a-4555-8a20-19f92a85cc6a">
