### PR TITLE
Fix student forum coloring

### DIFF
--- a/src/styles/lpp/dark.css
+++ b/src/styles/lpp/dark.css
@@ -191,3 +191,11 @@ html.dark .list-group-item-action:hover, html.dark .list-group-item-action:focus
   color: var(--message-fg);
   background-color: var(--message-bg);
 }
+
+html.dark .hsuforum-thread {
+  background-color: var(--message-bg);
+}
+
+html.dark .hsuforum-textarea {
+  background-color: black;
+}


### PR DESCRIPTION
Addresses some of #34 

I am not sure how to change the coloring on the extension itself.
It works fine on my machine and the coloring is correct:

<img width="674" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/bd9ca7cc-f09e-42f0-a530-443788e71003">

Currently solution to student forum coloring:

<img width="1680" alt="image" src="https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/37a2413e-4d30-4260-9e9f-b32399848521">

Previously:

![image](https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/94063597/e41a3dae-20e8-40be-8b97-7dbd958fd63e)
