### PR TITLE
Revive worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
+        "@plasmohq/messaging": "^0.6.0",
         "ical.js": "^1.5.0",
         "plasmo": "0.84.0",
         "react": "18.2.0",
@@ -20,7 +21,7 @@
         "@types/node": "20.9.0",
         "@types/react": "18.2.37",
         "@types/react-dom": "18.2.15",
-        "prettier": "3.0.3",
+        "prettier": "3.1.0",
         "typescript": "5.2.2"
       }
     },
@@ -3304,6 +3305,39 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@plasmohq/init/-/init-0.7.0.tgz",
       "integrity": "sha512-P75g48dqOGneJ+n0AcqnLE/TYflcaPc3B7h6EopnCBBYUDnCNBMwYmKAkaf5pnhsEB0ybPS6TU1C2DTGfqaW7A=="
+    },
+    "node_modules/@plasmohq/messaging": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@plasmohq/messaging/-/messaging-0.6.0.tgz",
+      "integrity": "sha512-iRyhtoWuS96YKZyga/nsBESXVzVrTQbyGRwR1/aNyWvuvt68G00Gtb6+zcWXd2uLSs5ExU/gYxakHYBbWqy2QA==",
+      "dependencies": {
+        "nanoid": "4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@plasmohq/messaging/node_modules/nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
     },
     "node_modules/@plasmohq/parcel-bundler": {
       "version": "0.5.5",
@@ -8018,9 +8052,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "plasmo test"
   },
   "dependencies": {
+    "@plasmohq/messaging": "^0.6.0",
     "plasmo": "0.84.0",
     "ical.js": "^1.5.0",
     "react": "18.2.0",

--- a/src/background.ts
+++ b/src/background.ts
@@ -80,11 +80,6 @@ const filter = {
   ],
 };
 
-chrome.webNavigation.onBeforeNavigate.addListener((details) => {
-  if (details.frameId !== 0) return
-  console.log("Before navigate", details)
-}, filter)
-
 chrome.webNavigation.onCommitted.addListener((details) => {
   if (details.frameId !== 0) return
   if (details.url && details.url.includes("learnit")) {
@@ -95,10 +90,10 @@ chrome.webNavigation.onCommitted.addListener((details) => {
 chrome.storage.onChanged.addListener((changes, namespace) => {
   if (namespace !== "local") return
   if (changes.theme) {
-    // we get issues if the old theme is null
-    // as we can't remove a null theme
-    // happens when the service worker is restarted
     const oldTheme = settings.theme
+      ? settings.theme 
+      : getTheme(changes.theme.oldValue)
+    
     settings.theme = getTheme(changes.theme.newValue)
 
     chrome.tabs.query({ url: "https://learnit.itu.dk/*" }, (tabs) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,6 @@
 /* Add styles to page */
 import { DarkModeState, getTheme, type theme } from "~/styles/main"
+export {}
 
 let injectedThemes: chrome.scripting.CSSInjection[] = []
 let settings: {
@@ -71,6 +72,11 @@ function initialInjection(tabId: number) {
   })
   injectCurrentTheme([tabId])
 }
+
+chrome.webNavigation.onBeforeNavigate.addListener((details) => {
+  if (details.frameId !== 0) return
+  console.log("Before navigate", details)
+})
 
 chrome.webNavigation.onCommitted.addListener((details) => {
   if (details.frameId !== 0) return

--- a/src/background/messages/awaiken.ts
+++ b/src/background/messages/awaiken.ts
@@ -1,0 +1,8 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+ 
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  console.log("Received message", req);
+  res.send("Im awake!");
+}
+
+export default handler

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -3,6 +3,7 @@ import "./nice-forms/nice-forms.css";
 import "./nice-forms/nice-forms-theme.css";
 import { themes, defaultTheme, DarkModeState } from "~/styles/main";
 import { useState, useEffect } from "react";
+import { sendToBackground } from "@plasmohq/messaging"
 
 function IndexPopup() {
   //@ts-ignore
@@ -16,7 +17,16 @@ function IndexPopup() {
     });
   }, []);
 
+
   function update(key: string, value: string | boolean) {
+    sendToBackground({
+      name: "awaiken",
+      body: {
+        input: "Hello from content script"
+      },
+    }).then((response) => {
+      console.log(response)
+    })
     chrome.storage.local.set({ [key]: value }, () => {
       setSettings({ ...settings, [key]: value });
     });


### PR DESCRIPTION
Currently, the service worker can die doing the use of Learnit. This pull request attempts to awaken the service worker and in the process has to change some of the injection logic. 

Currently, I am attempting to fix the popup by messaging the service worker to wake it. 
We previously had a variable with all the CSS set, but that won't work as the state will be lost when the service worker goes inactive. So now I try to use the tabs API and ask for all the tabs in our host. We don't need the TABS permission to use the tabs API for things in our host, as long as we don't need more than the tab id at least.

The only "issue" we might want to handle later is:
When the service worker is inactive and the theme is changed, then a single white flash happens. Changing the theme as long as the worker is alive makes no fash.