### PR TITLE
Grid recent items

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22,6 +22,13 @@ html .dashboard-card-deck.one-row {
   flex: 1;
 }
 
+/* Grid Recently accessed items */
+div .dashboard-card-deck.one-row:has(a+a) {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.3rem;
+}
+
 /* reorder dashboard cards */
 #block-region-content {
   display: grid !important;
@@ -83,6 +90,7 @@ html .block_timeline .timeline-action-button {
   margin-left: unset;
   margin: 0.5rem auto;
 }
+
 html .block_timeline .timeline-action-button .event-action {
   padding-left: unset;
 }
@@ -92,10 +100,12 @@ html nav.navbar.fixed-top .navbar-brand:before,
 html nav.navbar.fixed-top .navbar-brand:hover:before {
   content: "";
 }
+
 /*Remove background*/
 html .navbar.fixed-top .navbar-brand, html .navbar.fixed-top .navbar-brand:hover{
   background: none !important;
 }
+
 .site-name.navbar-brand {
   visibility: hidden;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -17,9 +17,18 @@ html .dashboard-card-deck.one-row {
 
 /* enable four items to be in the starred card */
 .dashboard-card-deck:not(.fixed-width-cards) .dashboard-card {
-  width: calc(25% - 0.5rem) !important;
+  width: unset !important;
   min-width: 150px;
   flex: 1;
+}
+
+/* remove stared courses padding */
+div .card-body {
+  padding: 0.8rem !important;
+}
+
+span + div.text-truncate {
+  white-space: collapse balance;
 }
 
 /* Grid Recently accessed items */


### PR DESCRIPTION
Fixes #61 

Recent items had an uneven and very small size. This pull request attempts to fix it by switching from flex to grid.
Before:
![image](https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/43612965/276aeedd-b25c-40f4-9a6f-c9784858e4dd)

Now:
![image](https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/43612965/6e97016a-3062-4865-8216-4a1ce8bdbede)


I also fixed some padding in the stared courses...
Before:
![image](https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/43612965/5b1e0426-4ce9-40b1-8b81-f00af0f61c93)

Now:
![image](https://github.com/PhilipFlyvholm/learnit-plus-plus/assets/43612965/b8fa943e-fec8-4569-95b0-7f450480ecbe)
