### PR TITLE
fix link in alert being invisible in dark mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
 
       - name: Cache pnpm modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
               ${{ runner.os }}-
 
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: latest
           run_install: true
 
-      - name: Use Node.js 21.x
-        uses: actions/setup-node@v4.0.0
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4.0.3
         with:
-          node-version: 21.x
+          node-version: 22.x
           cache: "pnpm"
 
       - name: Build and package the extension into a zip artifact 

--- a/src/styles/lpp/dark.css
+++ b/src/styles/lpp/dark.css
@@ -280,6 +280,6 @@ div .themeboostunioninfobanner.alert.alert-info {
   color: var(--brand-noticed-bg-color);
 }
 
-div .themeboostunioninfobanner.alert.alert-info > a {
-  color: #0198f0;
+html.dark .alert-info a {
+  color: var(--button-noticed-bg-color);
 }


### PR DESCRIPTION
The code for changing the link color was wrapped in a span which messed up the selector. The selector should no longer rely on its parent type.

![image](https://github.com/user-attachments/assets/a7b8b80e-a283-49ad-97c1-e0a45385eae8)

![image](https://github.com/user-attachments/assets/8d80a322-ad36-402f-937c-ef76f8aec45f)
